### PR TITLE
Remove extra .

### DIFF
--- a/app/assets/stylesheets/material_icons.css.erb
+++ b/app/assets/stylesheets/material_icons.css.erb
@@ -53,7 +53,7 @@
 
 /* Rules for using icons as black on a light background. */
 .material-icons.md-dark, .mi.md-dark { color: rgba(0, 0, 0, 0.54); }
-.material-icons.md-dark.md-inactive, .mi.md-dark.md-inactive. { color: rgba(0, 0, 0, 0.26); }
+.material-icons.md-dark.md-inactive, .mi.md-dark.md-inactive { color: rgba(0, 0, 0, 0.26); }
 
 /* Rules for using icons as white on a dark background. */
 .material-icons.md-light, .mi.md-light { color: rgba(255, 255, 255, 1); }


### PR DESCRIPTION
Hi Ángel,

I'm integrating your gem on MaterialUp and I've found a small error that doesn't make ActionView very happy. 

Here is the error I'm getting when running the specs:
```
Invalid CSS after "...rk.md-inactive.": expected class name, was ""
```