### PR TITLE
use material-icons instead of mi

### DIFF
--- a/app/models/material_icon.rb
+++ b/app/models/material_icon.rb
@@ -53,7 +53,7 @@ class MaterialIcon
     @css_class = " #{css_class}"
     self
   end
-  
+
   #
   # Add CSS properties to :i tag
   #
@@ -108,12 +108,12 @@ class MaterialIcon
       content_tag(:i, '',
                   @html.merge(
                     style: @style,
-                    class: "mi #{@icon}#{@size}#{@rotation}#{@css_class}"))
+                    class: "material-icons #{@icon}#{@size}#{@rotation}#{@css_class}"))
     else
       content_tag(:i, "#{@icon}",
                   @html.merge(
                     style: @style,
-                    class: "mi#{@size}#{@rotation}#{@css_class}"))
+                    class: "material-icons#{@size}#{@rotation}#{@css_class}"))
     end
   end
 

--- a/spec/helper/material_icon_helper_spec.rb
+++ b/spec/helper/material_icon_helper_spec.rb
@@ -1,15 +1,15 @@
 require 'spec_helper'
- 
+
 describe MaterialIcons::MaterialIconHelper do
   include MaterialIcons::MaterialIconHelper
 
   context 'Ligatures mode' do
     it 'generate the HTML code for an icon' do
-      expect(mi.face.r90.to_s).to eq '<i class="mi r90">face</i>'
+      expect(mi.face.r90.to_s).to eq '<i class="material-icons r90">face</i>'
       expect(mi.face.css_class('my_class').r90.to_s)
-        .to eq '<i class="mi r90 my_class">face</i>'
+        .to eq '<i class="material-icons r90 my_class">face</i>'
       expect(mi.face.css_class('my_class').style('margin-left: 10px;').r90.to_s)
-        .to eq '<i style="margin-left: 10px;" class="mi r90 my_class">face</i>'
+        .to eq '<i style="margin-left: 10px;" class="material-icons r90 my_class">face</i>'
     end
   end
 
@@ -25,11 +25,11 @@ describe MaterialIcons::MaterialIconHelper do
     end
 
     it 'generate the HTML code for an icon' do
-      expect(mi.face.r90.to_s).to eq '<i class="mi face r90"></i>'
+      expect(mi.face.r90.to_s).to eq '<i class="material-icons face r90"></i>'
       expect(mi.face.css_class('my_class').r90.to_s)
-        .to eq '<i class="mi face r90 my_class"></i>'
+        .to eq '<i class="material-icons face r90 my_class"></i>'
       expect(mi.face.css_class('my_class').style('margin-left: 10px;').r90.to_s)
-        .to eq '<i style="margin-left: 10px;" class="mi face r90 my_class"></i>'
+        .to eq '<i style="margin-left: 10px;" class="material-icons face r90 my_class"></i>'
     end
   end
 end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -9,9 +9,9 @@ describe 'home/index.html.erb' do
     it 'render the icons with the helper' do
       render
       # Check if the icons exist
-      expect(rendered).to have_selector('i.mi.r90', text: 'face')
-      expect(rendered).to have_selector('i.mi.r90.md-24', text: 'face')
-      expect(rendered).to have_selector('i.mi', text: '3d_rotation')
+      expect(rendered).to have_selector('i.material-icons.r90', text: 'face')
+      expect(rendered).to have_selector('i.material-icons.r90.md-24', text: 'face')
+      expect(rendered).to have_selector('i.material-icons', text: '3d_rotation')
     end
   end
 
@@ -29,9 +29,9 @@ describe 'home/index.html.erb' do
     it 'render the icons with the helper' do
       render
       # Check if the icons exist
-      expect(rendered).to have_selector('i.mi.r90.face', text: '')
-      expect(rendered).to have_selector('i.mi.r90.md-24.face', text: '')
-      expect(rendered).to have_selector('i.mi.three_d_rotation', text: '')
+      expect(rendered).to have_selector('i.material-icons.r90.face', text: '')
+      expect(rendered).to have_selector('i.material-icons.r90.md-24.face', text: '')
+      expect(rendered).to have_selector('i.material-icons.three_d_rotation', text: '')
     end
   end
 end


### PR DESCRIPTION
It's nice that this gem added the alias `.mi` to `.material-icons` but since the oficial project https://github.com/google/material-design-lite uses `.material-icons` in many of its css, I think this project should stick to the oficial use of the icons.