### PR TITLE
Correct the CSS to include Material Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your `application.css.erb` file you need to reference material icons CSS. The
 
 Add this line at top of `application.css.erb` to use ligature:
 
-	//= require material_icons
+	*= require material_icons
 
 These files provide multiple CSS classes to use in your views. Main classes are:
 
@@ -52,7 +52,7 @@ Don't forget to see material_icons.css.erb ;).
 Google Material Icons uses a feature called ligatures. We can define the icon in the text of the HTML tag. Go to [Google Guide](https://google.github.io/material-design-icons/#using-the-icons-in-html) to get more info.
 
 An example of icon is:
-	
+
 	<i class="material-icons">face</i>
 	<i class="material-icons md-36">face</i>
 
@@ -76,7 +76,7 @@ Material Icons provide two helpers to build the HTML code of icons. The methods 
 	# <i class="material-icons r90 my_class">face</i>
 
 Allowed methods are:
-	
+
 	# Rotation methods
 	r90
 	r180
@@ -103,7 +103,7 @@ Remember this is a helper, you always can use HTML syntax ;).
 
 # Compatibility
 
-Ligature feature requires a supported browser: 
+Ligature feature requires a supported browser:
 
 	Google Chrome       >= 11
 	Mozilla Firefox     >= 3.5
@@ -118,7 +118,7 @@ To increase compatibility you can use Unicode version of the library. To set Uni
 	//= require material_icons_unicode
 
 Next, you need to specify the helper to use unicode because it uses ligatures by default. Create an initializer file on `config/initializers/material_icon.rb` and set this content:
-	
+
 	# Initialize material icons setup
 	MaterialIcons.setup do |config|
 	  config.unicode = true
@@ -158,7 +158,7 @@ Rails versions:
 
 # They are using Material icons for Rails :)
 
-* [Materialup.com](http://www.materialup.com): a big community to share, discover and learn about Material Design. 
+* [Materialup.com](http://www.materialup.com): a big community to share, discover and learn about Material Design.
 
 # License
 


### PR DESCRIPTION
To include Material Icons in the Asset Pipeline, we should use ``*= require material_icons`` not ``//= require material_icons``.