### PR TITLE
Add the 'class_icon' method because we could not use an icon named 'class'

### DIFF
--- a/app/models/material_icon.rb
+++ b/app/models/material_icon.rb
@@ -7,7 +7,12 @@ class MaterialIcon
 
   # Undefined method will ref to the icon.
   def method_missing(name)
-    @icon = clear_icon(name)
+    @icon =
+      if name == :class_icon
+        'class' # Set the icon named 'class'
+      else
+        clear_icon(name)
+      end
     self
   end
 

--- a/spec/models/material_icon_spec.rb
+++ b/spec/models/material_icon_spec.rb
@@ -58,6 +58,29 @@ describe MaterialIcon do
       end
     end
 
+    # Class icon
+    describe '#class_icon' do
+
+      it 'should set the class icon when the method has no params' do
+        mi = MaterialIcon.new
+        # Set the icon and style
+        res = mi.class_icon
+        # Check icon
+        expect(mi.instance_variable_get('@icon')).to eq 'class'
+        expect(res.class).to eq MaterialIcon
+      end
+
+      it 'should set the class icon and style' do
+        mi = MaterialIcon.new
+        css_style = 'margin-top: 10px;'
+        # Set the icon and style
+        mi.class_icon.style css_style
+        # Check icon
+        expect(mi.instance_variable_get('@icon')).to eq 'class'
+        expect(mi.instance_variable_get('@style')).to eq css_style
+      end
+    end
+
     # Array join must be executed without any bug
     describe '#to_str' do
 


### PR DESCRIPTION
I could not use this icon named 'class', because name was duplicated with Object#class method.

https://material.io/tools/icons/?search=class&icon=class&style=baseline 

So, calling `mi.class_icon` now sets the class icon.
