### PR TITLE
[#42] Add the shape method and stop using missing method to set the icon

### DIFF
--- a/app/models/material_icon.rb
+++ b/app/models/material_icon.rb
@@ -5,17 +5,6 @@ class MaterialIcon
   # To use content_tag
   include ActionView::Helpers::TagHelper
 
-  # Undefined method will ref to the icon.
-  def method_missing(name)
-    @icon =
-      if name == :class_icon
-        'class' # Set the icon named 'class'
-      else
-        clear_icon(name)
-      end
-    self
-  end
-
   #
   # Reset will set all variables to nil
   #
@@ -45,6 +34,21 @@ class MaterialIcon
   end
 
   #
+  # Set the shape of the icon you want to use
+  #
+  # == Paremeters:
+  # name::
+  #    String or symbol with icon name
+  #
+  # == Returns:
+  # MaterialIcon instance
+  #
+  def shape(name)
+    @icon = name.to_s
+    self
+  end
+
+  #
   # Add a CSS class to :i tag
   #
   # == Paremeters:
@@ -70,40 +74,8 @@ class MaterialIcon
   # MaterialIcon instance
   #
   def style(css_style = '')
-    if css_style && css_style.empty?
-      # It references style icon
-      @icon = clear_icon('style')
-    else
-      # User wants to apply a style to the icon
-      @style = css_style
-    end
+    @style = css_style
     self
-  end
-
-  # Create an alias to use the original method
-  alias_method :super_send, :send
-
-  #
-  # Override send functionality to set the name of the icon to "send" when
-  # the method doesn't receive any parameters
-  #
-  # == Paremeters:
-  # name::
-  #    Name of the method to call
-  # args::
-  #    Arguments to send the method
-  #
-  # == Returns:
-  # MaterialIcon instance or the result of the method call
-  #
-  def send(name = '', *args)
-    if name && name.empty?
-      @icon = clear_icon('send')
-      # Return self
-      self
-    else
-      super_send(name.to_sym, *args)
-    end
   end
 
   #
@@ -152,24 +124,5 @@ class MaterialIcon
   #
   def to_ary
     nil
-  end
-
-  private
-
-  #
-  # Convert icon names that start with a number to the correct format. On
-  # Material Design Icons version 2.0.0, unique conflict is the 3d-rotation
-  # icon
-  #
-  # == Parameters:
-  # icon:
-  #   String with the name of the icon
-  #
-  # == Returns:
-  # An string with filtered name of the icon
-  #
-  def clear_icon(icon)
-    return icon if icon != :three_d_rotation
-    '3d_rotation'
   end
 end

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -1,10 +1,11 @@
 <h1>Testing Material icons gem!</h1>
 <h2>A set of icons</h2>
 
-<%= mi.face.r90 %>
-<%= material_icon.face.r90.md_24 %>
-<%# Special case %>
-<%= mi.three_d_rotation %>
+<%= mi.shape(:face).r90 %>
+<%# Define with a string %>
+<%= material_icon.shape('face').r90.md_24 %>
+<%# Shape with number %>
+<%= mi.shape('3d_rotation') %>
 
 <%# Safe join! %>
-<%= safe_join([mi.send.to_s, mi.book.to_s]) %>
+<%= safe_join([mi.shape(:send).to_s, mi.shape(:book).to_s]) %>

--- a/spec/helper/material_icon_helper_spec.rb
+++ b/spec/helper/material_icon_helper_spec.rb
@@ -4,17 +4,8 @@ describe MaterialIcons::MaterialIconHelper do
   include MaterialIcons::MaterialIconHelper
   
   it 'generate the HTML code for an icon' do
-    expect(mi.face.r90.to_s).to eq '<i class="material-icons r90">face</i>'
-    expect(mi.face.css_class('my_class').r90.to_s)
+    expect(mi.shape(:face).r90.to_s).to eq '<i class="material-icons r90">face</i>'
+    expect(mi.shape('face').css_class('my_class').r90.to_s)
       .to eq '<i class="material-icons r90 my_class">face</i>'
-    # On minor verions than Rails 4.2.0, the order of class/style inline
-    # attributes changes.
-    if Rails.version < '4.2.0'
-      expect(mi.face.css_class('my_class').style('margin-left: 10px;').r90.to_s)
-        .to eq '<i class="material-icons r90 my_class" style="margin-left: 10px;">face</i>'
-    else
-      expect(mi.face.css_class('my_class').style('margin-left: 10px;').r90.to_s)
-        .to eq '<i style="margin-left: 10px;" class="material-icons r90 my_class">face</i>'
-    end
   end
 end

--- a/spec/models/material_icon_spec.rb
+++ b/spec/models/material_icon_spec.rb
@@ -5,16 +5,7 @@ describe MaterialIcon do
   describe 'Icons with existing methods' do
     # Style icon
     describe '#Style' do
-      it 'should set the icon name when the method has no params' do
-        mi = MaterialIcon.new
-        # Set the icon and style
-        res = mi.style
-        # Check icon
-        expect(mi.instance_variable_get('@icon')).to eq 'style'
-        expect(res.class).to eq MaterialIcon
-      end
-
-      it 'should call style when the method has params' do
+      it 'should sets the style' do
         mi = MaterialIcon.new
         css_style = 'margin-top: 10px;'
         # Set the icon and style
@@ -25,17 +16,8 @@ describe MaterialIcon do
     end
 
     # Send icon
-    describe '#send' do
-      it 'should set the icon name when the method has no params' do
-        mi = MaterialIcon.new
-        # Set the icon and style
-        res = mi.send
-        # Check icon
-        expect(mi.instance_variable_get('@icon')).to eq 'send'
-        expect(res.class).to eq MaterialIcon
-      end
-
-      it 'should call to send when the method has params' do
+    describe '#send method' do
+      it 'should call to send method' do
         mi = MaterialIcon.new
         css_style = 'margin-top: 10px;'
         # Set the icon and style
@@ -52,32 +34,6 @@ describe MaterialIcon do
         # Send with arguments
         res2 = mi.send :inspect
         expect(res2.class).to eq String
-        # Only send
-        res3 = mi.send
-        expect(res3.class).to eq MaterialIcon
-      end
-    end
-
-    # Class icon
-    describe '#class_icon' do
-
-      it 'should set the class icon when the method has no params' do
-        mi = MaterialIcon.new
-        # Set the icon and style
-        res = mi.class_icon
-        # Check icon
-        expect(mi.instance_variable_get('@icon')).to eq 'class'
-        expect(res.class).to eq MaterialIcon
-      end
-
-      it 'should set the class icon and style' do
-        mi = MaterialIcon.new
-        css_style = 'margin-top: 10px;'
-        # Set the icon and style
-        mi.class_icon.style css_style
-        # Check icon
-        expect(mi.instance_variable_get('@icon')).to eq 'class'
-        expect(mi.instance_variable_get('@style')).to eq css_style
       end
     end
 
@@ -86,15 +42,15 @@ describe MaterialIcon do
 
       it 'should call to_s instead of executing method_missing' do
         mi = MaterialIcon.new
-        res = mi.face.to_str
+        res = mi.shape(:face).to_str
         expect(res).to eq mi.to_s
       end
 
       it 'the class should works when we use Array.join' do
         mi = MaterialIcon.new
         mi2 = MaterialIcon.new
-        expect([mi.face].join).to eq mi.to_s
-        expect([mi.face, mi2.send].join).to eq "#{mi}#{mi2}"
+        expect([mi.shape(:face)].join).to eq mi.to_s
+        expect([mi.shape(:face), mi2.shape(:send)].join).to eq "#{mi}#{mi2}"
       end
     end
   end


### PR DESCRIPTION
Stop using `missing_method` as the way to setup the icons. This was causing several issues over the time and now having many different icons starting with a number it makes it much more complicated. This PR drops support for this feature in favor of the `shape` method.